### PR TITLE
fix(#1238): bun adapter add qi to requests with query in guard but no…

### DIFF
--- a/test/adapter/bun/index.test.ts
+++ b/test/adapter/bun/index.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'bun:test'
+import { Elysia, t } from '../../../src'
+
+describe('Bun adapter', () => {
+    it('handle query guard', async () => {
+        const app = new Elysia()
+            .guard(({
+                query: t.Object({ a: t.String() }),
+            }))
+            .get("/works-with", ({ query }) => "Works" + query.a)
+            .get("/works-without", () => "Works without")
+            .listen(0)
+
+        const query = await fetch(
+                `http://localhost:${app.server!.port}/works-with?a=with`
+        ).then((x) => x.text())
+
+        expect(query).toEqual("Workswith")
+
+        const query2 = await fetch(
+            `http://localhost:${app.server!.port}/works-without?a=1`
+        ).then((x) => x.text())
+
+        expect(query2).toEqual("Works without")
+    })
+
+    it('handle standalone query guard', async () => {
+        const app = new Elysia()
+            .guard(({
+                query: t.Object({ a: t.String() }),
+                schema: "standalone"
+            }))
+            .get("/works-with", ({ query }) => "Works" + query.a)
+            .get("/works-without", () => "Works without")
+            .listen(0)
+
+        const query = await fetch(
+                `http://localhost:${app.server!.port}/works-with?a=with`
+        ).then((x) => x.text())
+
+        expect(query).toEqual("Workswith")
+
+        const query2 = await fetch(
+            `http://localhost:${app.server!.port}/works-without?a=1`
+        ).then((x) => x.text())
+
+        expect(query2).toEqual("Works without")
+    })
+})


### PR DESCRIPTION
…t in handler

## Summary by Sourcery

Broaden the Bun adapter’s query extraction logic to detect when route hooks or standalone validators use query parameters and ensure the query index (‘qi’) is computed and injected accordingly, and add tests to validate this behavior.

Bug Fixes:
- Always compute and include the ‘qi’ (query index) in the Bun adapter when any route hook or standalone validator references query parameters, even if the handler doesn’t infer a query.
- Update context creation and path resolution in the Bun adapter to rely on a unified ‘needsQuery’ flag instead of handler inference alone.

Tests:
- Add Bun adapter tests to cover query parsing in guards and handlers.